### PR TITLE
Reproduce via conda

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,3 +189,4 @@ dmypy.json
 
 # End of https://www.gitignore.io/api/python
 
+condaenv

--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@
 
 1. Install Anaconda for Python 3
 2. In the Anaconda terminal (Windows) or Unix-like terminal (other OS):
-    - Navigate to ./Code/
-    - run "pip install -r requirements.txt"
+    - Navigate to the root of this repository
+    - run `conda env update -f binder/environment.yml`
+    - run `conda activate ./condaenv`
 3. Run Spyder, and open ./do_min, ./do_mid.py, ./do_all.py, or ./do_custom.py
 4. Run the code by clicking the green arrow button.
 

--- a/reproduce.sh
+++ b/reproduce.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
 # DistributionOfWealth reproduce
 
-python -m pip install -r Code/requirements.txt
+if ! command -v conda &> /dev/null
+then
+    echo "`conda` (anaconda) needs to be installed to reproduce!"
+    exit
+fi
+
+conda env update -f binder/environment.yml --prefix ./condaenv/
+
+conda_root=$(conda info -s | grep CONDA_ROOT | sed 's/CONDA_ROOT\: //')
+source $conda_root/bin/activate ./condaenv
 
 ipython do_min.py


### PR DESCRIPTION
Previous PR #11 broke the `reproduce.sh` script as it still relied on a `requirements.txt` file to exist in the root of the repo. The `reproduce.sh` script will automatically create a conda environment for you that can execute the contents of this repo.

@alanlujan91 can you let me know what you think of this process is like for you? I'll probably need to flesh out the README.md instructions a little bit more but the general workflow will be.

## Execute reproduce.sh

If you have `conda` installed, this will work right out of the box:

```
cd root/to/repo
sh ./reproduce.sh
```

## Manual Reproductions

If you want to do anything outside of just running `reproduce.sh` you can:

```
cd root/of/repo
conda env update -f binder/environment.yml --prefix ./condaenv
conda activate ./condaenv

ipython do_min.py
...
```

---

The anaconda environment is stored in a folder called `condaenv` in the root of the repository. This folder has been added to `.gitignore` to prevent its contents from being uploaded to github.

## To Remove the Environment

```
cd root/of/repo
conda env remove --prefix ./condaenv
```